### PR TITLE
Update .soliumrc.json

### DIFF
--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -1,7 +1,8 @@
 {
   "extends": "solium:all",
   "plugins": [
-    "security"
+    "security",
+    "zeppelin"
   ],
   "rules": {
     "imports-on-top": ["error"],


### PR DESCRIPTION
Added zeppelin plugin to solium.
<s>Not sure if we need to add a dependency for `solium-plugin-zeppelin` in package.json or something tho?</s>

<s>
Need to also make sure that `solium-plugin-zeppelin` gets installed via `npm i`.
DO NOT MERGE (yet)
</s>

Looks like Zeppelin actually depreciated `solium` and `solium-plugin-zeppelin` for [solhint](https://github.com/protofire/solhint)
- https://github.com/OpenZeppelin/openzeppelin-contracts/issues/508