### PR TITLE
Update max balance on minimeToken event

### DIFF
--- a/app/src/components/Forms/RedeemTokens.js
+++ b/app/src/components/Forms/RedeemTokens.js
@@ -36,6 +36,11 @@ class RedeemTokens extends Component {
   //react to account balance changes
   componentDidUpdate(prevProps) {
     if (prevProps.balance != this.props.balance) {
+
+      this.setState(({ amount }) => ({
+        amount: { ...amount, max: this.props.balance }
+      }))
+      
       //recalculate new amount based on same progress and new balance
       this.handleSliderChange(this.state.progress)
     }
@@ -56,8 +61,8 @@ class RedeemTokens extends Component {
     const formattedBalance = formatAmount(balance, decimals)
 
     const rounding = Math.min(MAX_INPUT_DECIMAL_BASE, decimals)
-
     const amount = round(progress * formattedBalance, rounding)
+
     this.updateAmount(amount, progress)
   }
 

--- a/truffle.js
+++ b/truffle.js
@@ -55,6 +55,13 @@ module.exports = {
       port: 8545,
       network_id: '15',
     },
+    coverage: {
+      host: 'localhost',
+      network_id: '*',
+      port: 8555,
+      gas: 0xffffffffff,
+      gasPrice: 0x01,
+    },
     mainnet: {
       network_id: 1,
       provider: providerForNetwork('mainnet'),
@@ -62,13 +69,6 @@ module.exports = {
     rinkeby: {
       network_id: 4,
       provider: providerForNetwork('rinkeby'),
-    },
-    coverage: {
-      host: 'localhost',
-      network_id: '*',
-      port: 8555,
-      gas: 0xffffffffff,
-      gasPrice: 0x01,
     },
   },
   // Configure your compilers


### PR DESCRIPTION
When an account's redeemable token balance was updated, the `max` attribute for the redeeming input would not be refreshed.

This PR solves this issue