### PR TITLE
updated aragon ui to match the lock-app

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@aragon/api": "^2.0.0-beta.4",
     "@aragon/api-react": "^2.0.0-beta.4",
-    "@aragon/ui": "^0.40.1",
+    "@aragon/ui": "^1.0.0-alpha.19",
     "components": "^0.1.0",
     "core-js": "^3.1.4",
     "react": "^16.8.6",


### PR DESCRIPTION
Was going through the lock-app and saw that the Aragon UI dependency was upgraded to 1.0.0-alpha. Remembered that there was an open Issue here to upgrade the UI so I just copied what was in the lock-app. Hopefully closes #77 