### PR TITLE
Update apm staging rinkeby registry

### DIFF
--- a/arapp.json
+++ b/arapp.json
@@ -22,8 +22,8 @@
       "appName": "redemptions.open.aragonpm.eth"
     },
     "staging": {
-      "registry": "0x98df287b6c145399aaa709692c8d308357bc085d",
-      "appName": "redemptions-staging.open.aragonpm.eth",
+      "registry": "0xfe03625ea880a8cba336f9b5ad6e15b0a3b5a939",
+      "appName": "redemptions.open.aragonpm.eth",
       "wsRPC": "wss://rinkeby.eth.aragon.network/ws",
       "network": "rinkeby"
     },


### PR DESCRIPTION
APM Staging registry has been updated so we can use it now instead of using the traditional rinkeby apm repo with the `staging` tag  on the package name