### PR TITLE
Update rinkeby and mainnet appNames

### DIFF
--- a/arapp.json
+++ b/arapp.json
@@ -29,13 +29,13 @@
     },
     "rinkeby": {
       "registry": "0x98df287b6c145399aaa709692c8d308357bc085d",
-      "appName": "redemptions.open.aragonpm.eth",
+      "appName": "redemptions.aragonpm.eth",
       "wsRPC": "wss://rinkeby.eth.aragon.network/ws",
       "network": "rinkeby"
     },
     "mainnet": {
       "registry": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
-      "appName": "redemptions.open.aragonpm.eth",
+      "appName": "redemptions.aragonpm.eth",
       "wsRPC": "wss://mainnet.eth.aragon.network/ws",
       "network": "mainnet"
     }


### PR DESCRIPTION
Removes `.open` from app name