### PR TITLE
Enable dark mode

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@aragon/api": "^2.0.0-beta.4",
     "@aragon/api-react": "^2.0.0-beta.4",
-    "@aragon/ui": "^1.0.0-alpha.19",
+    "@aragon/ui": "^1.3.0",
     "components": "^0.1.0",
     "core-js": "^3.1.4",
     "react": "^16.8.6",

--- a/app/package.json
+++ b/app/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "main": "src/index.js",
   "dependencies": {
-    "@aragon/api": "^2.0.0-beta.4",
-    "@aragon/api-react": "^2.0.0-beta.4",
+    "@aragon/api": "^2.0.0-beta.9",
+    "@aragon/api-react": "^2.0.0-beta.9",
     "@aragon/ui": "^1.3.0",
     "components": "^0.1.0",
     "core-js": "^3.1.4",

--- a/app/src/App.js
+++ b/app/src/App.js
@@ -17,7 +17,7 @@ const App = React.memo(() => {
   const { appearance } = useGuiStyle()
 
   return (
-    <Main theme={appearance} assetsUrl="./aragon-ui">
+    <Main theme={appearance}>
       <SyncIndicator visible={isSyncing} />
       {tokens.length ? (
         <React.Fragment>

--- a/app/src/App.js
+++ b/app/src/App.js
@@ -9,14 +9,15 @@ import NoTokens from './screens/NoTokens'
 import UpdateTokens from './components/Panels/UpdateTokens'
 import RedeemTokens from './components/Panels/RedeemTokens'
 
-import { AppLogicProvider, useAppLogic } from './app-logic'
+import { AppLogicProvider, useAppLogic, useGuiStyle } from './app-logic'
 import { MODE } from './mode-types'
 
 const App = React.memo(() => {
   const { actions, requests, isSyncing, burnableToken, tokens, panelState, mode } = useAppLogic()
+  const { appearance } = useGuiStyle()
 
   return (
-    <Main>
+    <Main theme={appearance} assetsUrl="./aragon-ui">
       <SyncIndicator visible={isSyncing} />
       {tokens.length ? (
         <React.Fragment>

--- a/app/src/app-logic.js
+++ b/app/src/app-logic.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react'
-import { AragonApi, useAppState, useApi } from '@aragon/api-react'
+import { AragonApi, useAppState, useApi, useGuiStyle } from '@aragon/api-react'
 
 import { useSidePanel } from './hooks/utils-hooks'
 import appStateReducer from './app-state-reducer'
@@ -84,3 +84,5 @@ export function useAppLogic() {
 export function AppLogicProvider({ children }) {
   return <AragonApi reducer={appStateReducer}>{children}</AragonApi>
 }
+
+export { useGuiStyle }

--- a/app/src/components/Message.js
+++ b/app/src/components/Message.js
@@ -1,11 +1,9 @@
 import React from 'react'
 import { Info, IconCross, useTheme, textStyle } from '@aragon/ui'
 
-export const InfoMessage = ({ title, text, background }) => (
+export const InfoMessage = ({ title, text }) => (
   <div style={{ marginBottom: '1rem' }}>
-    <Info.Action title={title} background={background}>
-      {text}
-    </Info.Action>
+    <Info title={title}>{text}</Info>
   </div>
 )
 


### PR DESCRIPTION
I couldn't test it properly because the redemptions app gives me this error:

```
Minified React error #130; visit https://reactjs.org/docs/error-decoder.html?invariant=130&args[]=undefined&args[]= for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
```

Can somebody test it properly with the last aragon/aragon on dark mode?

**EDIT:** The change in the `<Info>` box fixed the problem.

![Screenshot from 2020-02-14 10-53-26](https://user-images.githubusercontent.com/931684/74520685-5c071980-4f18-11ea-8347-e07b5977fc5b.png)
